### PR TITLE
Fix TypeError for params and loop of removing old backup files

### DIFF
--- a/backup_hoi4_saves.py
+++ b/backup_hoi4_saves.py
@@ -53,12 +53,14 @@ def backup_hoi4_saves(*,max_saves=52,delta_minutes_min=5,copy_delay=60,backup_di
         if autosave_time > max(filetimes)+datetime.timedelta(minutes=delta_minutes_min):
             shutil.copyfile(autosave, backup_path + "autosave" + autosave_time.strftime("%m.%d.%H.%M") + ".hoi4")
 
-        while len(filetimes) > max_saves:
+        num_files = len(filetimes)
+        while num_files > max_saves:
             files=[Path(backup_path + file) for file in os.listdir(backup_path)]
             files.sort(key=os.path.getmtime)
             oldest_file=files[0]
             print("Removing {}".format(oldest_file))
             os.remove(oldest_file)
+            num_files = num_files - 1
         time.sleep(copy_delay)
 
 
@@ -69,7 +71,7 @@ if __name__ == '__main__':
         parms={}
         for item in sys.argv[1:]:
             key,val = item.split("=")
-            if key in ("maxtime","copy_delay"):
+            if key in ("maxtime","copy_delay","delta_minutes_min","max_saves"):
                 parms[key]=int(val)
             else:
                 parms[key]=val

--- a/backup_hoi4_saves.py
+++ b/backup_hoi4_saves.py
@@ -50,7 +50,7 @@ def backup_hoi4_saves(*,max_saves=52,delta_minutes_min=5,copy_delay=60,backup_di
 
         autosave_time = datetime.datetime.fromtimestamp(os.stat(autosave).st_mtime)
 
-        if autosave_time > max(filetimes)+datetime.timedelta(minutes=delta_minutes_min):
+        if len(filetimes) == 0 or autosave_time > max(filetimes)+datetime.timedelta(minutes=delta_minutes_min):
             shutil.copyfile(autosave, backup_path + "autosave" + autosave_time.strftime("%m.%d.%H.%M") + ".hoi4")
 
         num_files = len(filetimes)


### PR DESCRIPTION
First of all, I genuinely appreciate this Python script for backing up the autosave files. It saves me and my friends a lot of hassle when doing silly things and experiments in multiplayer games. However, I've encountered two problems with this script, and I would like to provide the fixes to these problems.

First, if `delta_minutes_min` or `max_saves` param were used, the script will run into a TypeError because they are not properly cast into `int` type.

Second, although not sure if it's an intended behavior, the old file removal loop will delete ALL backups from the last run when a new autosave is detected, and it will keep deleting files until `files[0]` is out of index. This is caused by `len(filetimes)` not reflecting the true number of the files that remain in the backup folder. Now it will only remove the oldest one when the number of files exceeds the desired max_saves.

The modification of codes in this PR should resolve the above issues.